### PR TITLE
Update getBondStatus

### DIFF
--- a/getBondStatus
+++ b/getBondStatus
@@ -224,7 +224,7 @@ sub _get_bond_capability()
 }
 
 sub main {
-    if(@ARGV < 1) { print "Error:\n";Usage; return; }
+    if(@ARGV < 1) { Usage; return; }
     GetOptions ('h' => \&Usage, 'd' => \$debug, 'i=s' => \&_get_bond_capability,
                 's=s' => \&_get_bond_capability, 'S=s' => \&_get_bond_capability,
                 'l' => \&get_bonded_interfaces,


### PR DESCRIPTION
When getBondStatus.sh is executed without any parameters Help/Usage message thrown has "Error" tag. As it adds no value to the help message removing the same.
